### PR TITLE
attempt to address issue #1

### DIFF
--- a/include/lamport_clock.h
+++ b/include/lamport_clock.h
@@ -3,7 +3,8 @@
 
 #include <atomic>
 
-class LamportClock {
+class LamportClock
+{
 public:
     /// Lamport timestamp
     typedef unsigned int LamportTime;
@@ -15,7 +16,8 @@ public:
      *
      * @return LamportTime value.
      */
-    LamportTime get_time() const {
+    LamportTime get_time() const
+    {
         return time_.load();
     }
 
@@ -25,7 +27,8 @@ public:
      *
      * @return LamportTime value;
      */
-    LamportTime local_event() {
+    LamportTime local_event()
+    {
         return time_.fetch_add(1);
     }
 
@@ -35,7 +38,8 @@ public:
      *
      * @return LamportTime value;
      */
-    LamportTime send_event() {
+    LamportTime send_event()
+    {
         return time_.fetch_add(1);
     }
 
@@ -46,18 +50,21 @@ public:
      * @param received_time Sender's time.
      * @return LamportTime value;
      */
-    LamportTime receive_event(LamportTime received_time) {
-        RECEIVE_EVENT:
+    LamportTime receive_event(LamportTime received_time)
+    {
+    RECEIVE_EVENT:
 
         auto cur = get_time();
 
-        // If received time is old, do nothing.
-        if (received_time < cur) {
-            return cur;
+        // If received time is old, current time is max(current, receive).
+        if (received_time < cur)
+        {
+            return time_.fetch_add(1);
         }
 
         // Ensure that local timer is at least one ahead.
-        if (!time_.compare_exchange_strong(cur, received_time + 1)) {
+        if (!time_.compare_exchange_strong(cur, received_time + 1))
+        {
             goto RECEIVE_EVENT;
         }
 

--- a/tests/lamport_clock_tests/lamport_clock_tests.cpp
+++ b/tests/lamport_clock_tests/lamport_clock_tests.cpp
@@ -25,5 +25,8 @@ TEST(LamportClock_Test, ReceiveEvent) {
     ASSERT_EQ(clock.get_time(), 4);
 
     clock.receive_event(2);
-    ASSERT_EQ(clock.get_time(), 4);
+    ASSERT_EQ(clock.get_time(), 5);
+
+    clock.receive_event(5);
+    ASSERT_EQ(clock.get_time(), 6);
 }


### PR DESCRIPTION
Shouldn't have also used autoformatting, the really relevant part is line 62 of lamport_clock.h, where if the current time is the max of the received and the current time, so the current time gets incremented and returned. 

This does pass the test proposed in issue #1